### PR TITLE
Don't pre-set the root or prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ doc:
 	$(MAKE) -f doc/Makefile html
 
 install:
-	env python2 setup.py install --root $(DESTDIR) --prefix $(PREFIX) --exec-prefix $(PREFIX)
+	env python2 setup.py install
 
 .PHONY : doc
 .PHONY : install


### PR DESCRIPTION
Don't pre-fill the PREFIX because it breaks for Python that isn't installed in /usr/local. Fixes #3.
