### PR TITLE
Added search path: '/Applications/Arduino.app/Contents/Java/'

### DIFF
--- a/ano/environment.py
+++ b/ano/environment.py
@@ -87,6 +87,7 @@ class Environment(dict):
 
     if platformSystem == 'Darwin':
         arduino_dist_dir_guesses.insert(0, '/Applications/Arduino.app/Contents/Resources/Java')
+        arduino_dist_dir_guesses.insert(0, '/Applications/Arduino.app/Contents/Java')
     elif platformSystem == 'Windows':
         arduino_user_dir_guesses.insert(0, os.path.expanduser(os.path.join("~", "My Documents", "Arduino")))
 


### PR DESCRIPTION
For some reason I was getting the "Board description file (boards.txt) not found" error on my Mac (10.10) with Arduino 1.6.1.

I found where the search path is specified in ano/environments.py and added this path which leads to the correct file.

I'm not sure if any installations use the old path  ('/Applications/Arduino.app/Contents/Resources/Java') but I didn't want to delete it.

Thanks for all the work on this project. 
