### PR TITLE
add: Argument to quell upload command

### DIFF
--- a/ano/commands/upload.py
+++ b/ano/commands/upload.py
@@ -32,6 +32,8 @@ class Upload(Command):
         super(Upload, self).setup_arg_parser(parser)
         parser.add_argument('-p', '--serial-port', metavar='PORT',
                             help='Serial port to upload firmware to\nTry to guess if not specified')
+        parser.add_argument('-q', '--quiet', default=False, action='store_true',
+                            help='Quell progress output')
 
         self.e.add_board_model_arg(parser)
         self.e.add_arduino_dist_arg(parser)
@@ -137,5 +139,6 @@ class Upload(Command):
             '-c', protocol,
             '-b', BoardModels.getValueForVariant(board, boardVariant, 'upload', 'speed'),
             '-D',
+            '-qq' if args.quiet else '',
             '-U', 'flash:w:%s:i' % self.e['hex_path'],
         ])


### PR DESCRIPTION
Regarding my issue #63 I added an argument: -q or --quiet to pass the argument -qq to avrdude making it quiet unless an error occurs. The reason is that otherwise the upload progress is printed to the stderr which is annoying for scripting.
