### PR TITLE
Properly escape include directories

### DIFF
--- a/ano/commands/build.py
+++ b/ano/commands/build.py
@@ -252,8 +252,8 @@ class Build(Command):
     def recursive_inc_lib_flags(self, libdirs):
         flags = SpaceList()
         for d in libdirs:
-            flags.append('-I' + d)
-            flags.extend('-I' + subd for subd in list_subdirs(d, recursive=True, exclude=['examples', 'extras']))
+            flags.append('-I' + "\"" + d + "\"")
+            flags.extend('-I' + "\"" + subd + "\"" for subd in list_subdirs(d, recursive=True, exclude=['examples', 'extras']))
         return flags
 
     def _scan_dependencies(self, dirName, lib_dirs, inc_flags):


### PR DESCRIPTION
I was running into problems in which directories with spaces in their names were not being properly escaped, and it was causing builds to fail.

This might be needed in other places too, but I have not yet checked.
